### PR TITLE
feat: remove github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/libdns/namedotcom
 
 go 1.16
 
-require (
-	github.com/libdns/libdns v0.2.2
-	github.com/pkg/errors v0.9.1
-)
+require github.com/libdns/libdns v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
 github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/namedotcom.go
+++ b/namedotcom.go
@@ -5,6 +5,7 @@ package namedotcom
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,7 +15,6 @@ import (
 	"time"
 
 	"github.com/libdns/libdns"
-	"github.com/pkg/errors"
 )
 
 // default timeout for the http request handler (seconds)
@@ -77,10 +77,10 @@ func (n *nameDotCom) errorResponse(resp *http.Response) error {
 	er := &errorResponse{}
 	err := json.NewDecoder(resp.Body).Decode(er)
 	if err != nil {
-		return errors.Wrap(err, "api returned unexpected response")
+		return fmt.Errorf("api returned unexpected response: %w", err)
 	}
 
-	return errors.WithStack(er)
+	return er
 }
 
 // doRequest is the base http request handler including a request context.


### PR DESCRIPTION
Remove deprecated `github.com/pkg/errors` package.